### PR TITLE
Fix newer compiler complaints

### DIFF
--- a/kernel/src/Boot/Patches.hpp
+++ b/kernel/src/Boot/Patches.hpp
@@ -21,6 +21,7 @@ namespace Mira
             static void install_prerunPatches_620();
             static void install_prerunPatches_650();
             static void install_prerunPatches_672();
+            static void install_prerunPatches_702();
             static void install_prerunPatches_750();
             static void install_prerunPatches_751();
             static void install_prerunPatches_755();

--- a/kernel/src/Plugins/FakeSelf/FakeSelfManager.cpp
+++ b/kernel/src/Plugins/FakeSelf/FakeSelfManager.cpp
@@ -431,7 +431,10 @@ int FakeSelfManager::SceSblAuthMgrSmLoadSelfSegment_Mailbox(uint64_t p_ServiceId
     auto sceSblServiceMailbox = (int(*)(uint32_t p_ServiceId, void* p_Request, void* p_Response))kdlsym(sceSblServiceMailbox);
 
 	// self_context is first param of caller. 0x08 = sizeof(struct self_context*)
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wframe-address"
 	uint8_t* frame = (uint8_t*)__builtin_frame_address(1);
+    #pragma clang diagnostic pop
 	SelfContext* s_Context = *(SelfContext**)(frame - 0x08);
 
     auto s_RequestMessage = static_cast<MailboxMessage*>(p_Request);
@@ -461,7 +464,10 @@ int FakeSelfManager::SceSblAuthMgrSmLoadSelfSegment_Mailbox(uint64_t p_ServiceId
 int FakeSelfManager::SceSblAuthMgrSmLoadSelfBlock_Mailbox(uint64_t p_ServiceId, uint8_t* p_Request, void* p_Response)
 {
     // self_context is first param of caller. 0x08 = sizeof(struct self_context*)
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wframe-address"
     uint8_t* frame = (uint8_t*)__builtin_frame_address(1);
+    #pragma clang diagnostic pop
     SelfContext* p_Context = *(SelfContext**)(frame - 0x08);
 
     bool s_IsUnsigned = p_Context && (p_Context->format == SelfFormat::Elf || IsFakeSelf((SelfContext*)p_Context));

--- a/kernel/src/Utils/New.cpp
+++ b/kernel/src/Utils/New.cpp
@@ -18,6 +18,7 @@ void * operator new(unsigned long int p_Size)
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnew-returns-null"
+#pragma clang diagnostic ignored "-Wnonnull"
 	if (p_Size == 0)
 		return nullptr;
 #pragma clang diagnostic pop


### PR DESCRIPTION
* Missing header definition for `install_prerunPatches_702()`
* Ignore frame address warning
* Ignore null return warning